### PR TITLE
Calendar : Fix i18n bug

### DIFF
--- a/packages/calendar/src/date-table.vue
+++ b/packages/calendar/src/date-table.vue
@@ -22,8 +22,8 @@ export default {
   
   data() {
     return {
-      WEEK_DAYS: getI18nSettings().dayNames;
-    }
+      WEEK_DAYS: getI18nSettings().dayNames
+    };
   },
   
   methods: {


### PR DESCRIPTION
I moved variable `WEEK_DAYS` declaration in `root` to `data`.

In root declaration, `getI18nSettings()` couldn't get changed i18n settings.